### PR TITLE
Fix Vercel module assuming JSON as MIME type

### DIFF
--- a/statusng/Cargo.lock
+++ b/statusng/Cargo.lock
@@ -628,7 +628,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "statusng"
-version = "3.0.2"
+version = "3.0.3"
 dependencies = [
  "chrono",
  "log",

--- a/statusng/Cargo.toml
+++ b/statusng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statusng"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2021"
 
 [dependencies]

--- a/statusng/src/export/private.rs
+++ b/statusng/src/export/private.rs
@@ -118,7 +118,7 @@ impl PrivateAPI {
         let vercel = Vercel::new(token);
 
         fs::write("./output.dat", &data)?;
-        vercel.put(&data, "public/status.dat", 360)?;
+        vercel.put(&data, "public/status.dat", 360, "application/vnd.equestriadev.statusng")?;
 
         Ok(())
     }

--- a/statusng/src/export/public.rs
+++ b/statusng/src/export/public.rs
@@ -37,8 +37,8 @@ impl<'a> PublicAPI<'a> {
         let vercel = Vercel::new(token);
 
         fs::write("./out-public.json", &data)?;
-        vercel.put(&data.as_bytes(), "public/api-v2.json", 360)?;
-        vercel.put(&data.as_bytes(), "public/api.json", 360)?;
+        vercel.put(&data.as_bytes(), "public/api-v2.json", 360, "application/json")?;
+        vercel.put(&data.as_bytes(), "public/api.json", 360, "application/json")?;
 
         Ok(())
     }

--- a/statusng/src/export/vercel.rs
+++ b/statusng/src/export/vercel.rs
@@ -9,7 +9,7 @@ impl<'a> Vercel<'a> {
         Self { token }
     }
 
-    pub fn put(&self, data: &[u8], path: &str, max_age: u32) -> Result<(), StatusError> {
+    pub fn put(&self, data: &[u8], path: &str, max_age: u32, mime_type: &str) -> Result<(), StatusError> {
         let url = format!("https://blob.vercel-storage.com/{path}");
         let authorization = format!("Bearer {}", self.token);
 
@@ -17,7 +17,7 @@ impl<'a> Vercel<'a> {
             .set("Access", "public")
             .set("Authorization", &authorization)
             .set("X-API-Version", "7")
-            .set("X-Content-Type", "application/json")
+            .set("X-Content-Type", mime_type)
             .set("X-Cache-Control-Max-Age", &max_age.to_string())
             .set("X-Add-Random-Suffix", "0")
             .send_bytes(data)?;


### PR DESCRIPTION
This change fixes the fact that the Vercel module will set the MIME type of pushed files to always be `application/json`, regardless of the actual type of the data. It adds a new `mime_type` parameter to the `put` method, and uses `application/vnd.equestriadev.statusng` for the private API data.